### PR TITLE
Improve progress bar display with follow-up question counter

### DIFF
--- a/rollplay.py
+++ b/rollplay.py
@@ -447,7 +447,14 @@ def show_question_stage():
     
     # 進捗表示
     progress = (st.session_state.current_question + 1) / len(questions_list)
-    st.progress(progress, f"質問 {st.session_state.current_question + 1} / {len(questions_list)}")
+    
+    # 深掘り回数の表示を追加
+    if st.session_state.depth_count > 0:
+        depth_info = f" - 深掘り質問{st.session_state.depth_count}回目（最大3回）"
+    else:
+        depth_info = ""
+    
+    st.progress(progress, f"質問 {st.session_state.current_question + 1} / {len(questions_list)}{depth_info}")
     
     if st.session_state.current_question < len(questions_list):
         selected_q = questions_list[st.session_state.current_question]


### PR DESCRIPTION
- Added follow-up question counter to progress bar display
- Shows "深掘り質問X回目（最大3回）" when in follow-up mode
- Helps users understand why question number doesn't advance during follow-ups
- Improves user experience by clarifying interview flow

Issue：[リンク](https://github.com/harappa8921/mensetsu_rollplay/issues/8)